### PR TITLE
feat: add Daily VA, shade toggle, timeframe labels, repositioned labels

### DIFF
--- a/yearly_anchored_vwap.pine
+++ b/yearly_anchored_vwap.pine
@@ -1,64 +1,86 @@
-// =============================================================================
-// Yearly Anchored VWAP + Standard Deviation Bands
-// Reverse-engineered from: "VWAP - Daily" column in long-term VWAP CSV export
-//
-// CONFIDENCE: ~90% (upgraded after backtest)
-//   - Yearly reset (Jan 1) confirmed by data: at timestamp 1767225600
-//     (2026-01-01) VWAP = VAH = VAL (SD=0, first bar of new year)
-//   - SD formula: population variance via Σ(TP²·V)/ΣV − VWAP²
-//   - SD bands are symmetric (verified to full float precision)
-//   - TP formula: BACKTEST CONFIRMED → use close, not (H+L+C)/3
-//     At bar 1 of new year: close gives VWAP error=4.39 vs 313.85 for HLC/3
-//     Residual error due to tick-level VWAP in TradingView vs daily OHLC approx
-//
-// COLUMNS REPLICATED:
-//   VWAP - Daily  →  vwap  (blue)
-//   SD#1 VAH      →  vwap + 1·sd
-//   SD#1 VAL      →  vwap − 1·sd
-//   SD+2 / SD-2   →  vwap ± 2·sd   (empty in CSV; included here as optional)
-//   SD+3 / SD-3   →  vwap ± 3·sd   (empty in CSV; included here as optional)
-//   Previous VWAP →  prev_vwap      (empty in CSV; shown as flat reference)
-//   Prev VAH/VAL  →  prev_vwap ± prev_sd
-// =============================================================================
+//@version=6
+indicator("Multi-TF VWAP + Value Areas", shorttitle="VWAP-MTF", overlay=true, max_lines_count=20, max_labels_count=50)
 
-//@version=5
-indicator("Yearly Anchored VWAP + SD Bands", shorttitle="VWAP-Y", overlay=true)
+// ── Timeframe ─────────────────────────────────────────────────────────────────
+tf_mode = input.string("Auto", "Timeframe",
+     options=["Auto", "Yearly", "Quarterly", "Monthly", "Weekly", "Daily"],
+     group="Timeframe")
 
-// ── Inputs ───────────────────────────────────────────────────────────────────
-var string g_disp  = "Display"
-var string g_color = "Colors"
+// ── Display ───────────────────────────────────────────────────────────────────
+show_sd1   = input.bool(true,  "Show Value Area (±1 SD)",        group="Display")
+show_sd2   = input.bool(false, "Show ±2 SD Bands",               group="Display")
+show_sd3   = input.bool(false, "Show ±3 SD Bands",               group="Display")
+show_prev  = input.bool(true,  "Show Previous Period",            group="Display")
+shade_dev  = input.bool(true,  "Shade Developing Value Area",     group="Display")
+shade_prev = input.bool(false, "Shade Previous Value Area",       group="Display")
+show_lbl   = input.bool(true,  "Show Labels",                     group="Display")
+show_ext   = input.bool(true,  "Extend Developing Lines to RHS",  group="Display")
 
-show_sd1  = input.bool(true,  "Show ±1 SD Bands",         group=g_disp)
-show_sd2  = input.bool(false, "Show ±2 SD Bands",         group=g_disp)
-show_sd3  = input.bool(false, "Show ±3 SD Bands",         group=g_disp)
-show_prev = input.bool(true,  "Show Previous Year VWAP",  group=g_disp)
+// ── Colours: Developing ───────────────────────────────────────────────────────
+c_vwap     = input.color(color.new(#2196F3, 0),  "VWAP",            group="Colours: Developing")
+c_vah      = input.color(color.new(#4CAF50, 0),  "VAH",             group="Colours: Developing")
+c_val      = input.color(color.new(#4CAF50, 0),  "VAL",             group="Colours: Developing")
+c_sd2      = input.color(color.new(#FF9800, 20), "±2 SD",           group="Colours: Developing")
+c_sd3      = input.color(color.new(#F44336, 20), "±3 SD",           group="Colours: Developing")
+c_fill_dev = input.color(color.new(#4CAF50, 85), "Value Area Fill", group="Colours: Developing")
 
-c_vwap = input.color(color.new(#2196F3, 0),  "VWAP",            group=g_color)
-c_sd1  = input.color(color.new(#4CAF50, 20), "±1 SD",           group=g_color)
-c_sd2  = input.color(color.new(#FF9800, 20), "±2 SD",           group=g_color)
-c_sd3  = input.color(color.new(#F44336, 20), "±3 SD",           group=g_color)
-c_prev = input.color(color.new(#9E9E9E, 40), "Prev Year VWAP",  group=g_color)
+// ── Colours: Previous ─────────────────────────────────────────────────────────
+c_pvwap    = input.color(color.new(#9E9E9E, 30), "Prev VWAP",       group="Colours: Previous")
+c_pvah     = input.color(color.new(#9E9E9E, 30), "Prev VAH",        group="Colours: Previous")
+c_pval     = input.color(color.new(#9E9E9E, 30), "Prev VAL",        group="Colours: Previous")
+c_fill_prv = input.color(color.new(#9E9E9E, 85), "Value Area Fill", group="Colours: Previous")
 
-// ── Accumulators (reset each Jan 1) ─────────────────────────────────────────
-var float cum_tpv  = 0.0   // Σ( TP × Volume )
-var float cum_vol  = 0.0   // Σ( Volume )
-var float cum_tp2v = 0.0   // Σ( TP² × Volume )  — needed for variance
+// ── Colours: Labels ───────────────────────────────────────────────────────────
+c_lbl_d_bg = input.color(color.new(#2196F3, 10), "Dev Label BG",    group="Colours: Labels")
+c_lbl_d_tx = input.color(color.white,             "Dev Label Text",  group="Colours: Labels")
+c_lbl_p_bg = input.color(color.new(#9E9E9E, 10), "Prev Label BG",   group="Colours: Labels")
+c_lbl_p_tx = input.color(color.white,             "Prev Label Text", group="Colours: Labels")
 
-// Previous year's final VWAP + SD (held as static reference after year rolls)
+// ── Effective timeframe ───────────────────────────────────────────────────────
+// Auto TF thresholds (timeframe.in_seconds()):
+//   >= 86400s (1 day)   → Yearly
+//   >  14400s (4 hours) → Quarterly
+//   >= 3600s  (1 hour)  → Monthly
+//   >= 1800s  (30 min)  → Weekly
+//   <  1800s            → Daily
+tf_secs = timeframe.in_seconds()
+
+eff_tf = tf_mode != "Auto" ? tf_mode :
+         tf_secs >= 86400  ? "Yearly" :
+         tf_secs >  14400  ? "Quarterly" :
+         tf_secs >= 3600   ? "Monthly" :
+         tf_secs >= 1800   ? "Weekly" : "Daily"
+
+// ── Period detection ──────────────────────────────────────────────────────────
+cur_q  = month(time) <= 3 ? 1 : month(time) <= 6 ? 2 : month(time) <= 9 ? 3 : 4
+prev_q = barstate.isfirst ? 0 : (month(time[1]) <= 3 ? 1 : month(time[1]) <= 6 ? 2 : month(time[1]) <= 9 ? 3 : 4)
+
+new_year  = barstate.isfirst ? true : year(time)       != year(time[1])
+new_qtr   = new_year         ? true : cur_q            != prev_q
+new_month = new_qtr          ? true : month(time)      != (barstate.isfirst ? -1 : month(time[1]))
+new_week  = new_month        ? true : weekofyear(time) != (barstate.isfirst ? -1 : weekofyear(time[1]))
+new_day   = new_week         ? true : dayofmonth(time) != (barstate.isfirst ? -1 : dayofmonth(time[1]))
+
+new_period = eff_tf == "Yearly"    ? new_year  :
+             eff_tf == "Quarterly" ? new_qtr   :
+             eff_tf == "Monthly"   ? new_month :
+             eff_tf == "Weekly"    ? new_week  : new_day
+
+// ── VWAP computation ──────────────────────────────────────────────────────────
+var float cum_tpv  = 0.0
+var float cum_vol  = 0.0
+var float cum_tp2v = 0.0
 var float prev_vwap = na
 var float prev_sd   = na
 
-tp       = close  // Backtest confirmed: close outperforms (H+L+C)/3 by 70x (error 4.39 vs 313.85)
-new_year = year(time) != year(time[1]) or barstate.isfirst
+tp = close
 
-if new_year
-    // Snapshot the completed year before resetting
-    if cum_vol > 0
-        float _pv  = cum_tpv  / cum_vol
+if new_period
+    if cum_vol > 0.0
+        float _pv  = cum_tpv / cum_vol
         float _var = math.max(cum_tp2v / cum_vol - _pv * _pv, 0.0)
         prev_vwap := _pv
         prev_sd   := math.sqrt(_var)
-    // Reset for new year
     cum_tpv  := tp * volume
     cum_vol  := volume
     cum_tp2v := tp * tp * volume
@@ -67,30 +89,140 @@ else
     cum_vol  += volume
     cum_tp2v += tp * tp * volume
 
-vwap     = cum_tpv / cum_vol
-variance = math.max(cum_tp2v / cum_vol - vwap * vwap, 0.0)
-sd       = math.sqrt(variance)
+vwap     = cum_vol > 0.0 ? cum_tpv / cum_vol : na
+_raw_var = cum_vol > 0.0 ? math.max(cum_tp2v / cum_vol - vwap * vwap, 0.0) : na
+sd       = not na(_raw_var) ? math.sqrt(_raw_var) : na
 
-// ── Current-year plots ───────────────────────────────────────────────────────
-plot(vwap,                        "VWAP",   c_vwap, 2)
-plot(show_sd1 ? vwap + sd   : na, "VAH +1", c_sd1,  1)
-plot(show_sd1 ? vwap - sd   : na, "VAL -1", c_sd1,  1)
-plot(show_sd2 ? vwap + 2*sd : na, "VAH +2", c_sd2,  1)
-plot(show_sd2 ? vwap - 2*sd : na, "VAL -2", c_sd2,  1)
-plot(show_sd3 ? vwap + 3*sd : na, "VAH +3", c_sd3,  1)
-plot(show_sd3 ? vwap - 3*sd : na, "VAL -3", c_sd3,  1)
+vhi  = not na(sd) ? vwap + sd        : na
+vlo  = not na(sd) ? vwap - sd        : na
+vhi2 = not na(sd) ? vwap + 2.0 * sd  : na
+vlo2 = not na(sd) ? vwap - 2.0 * sd  : na
+vhi3 = not na(sd) ? vwap + 3.0 * sd  : na
+vlo3 = not na(sd) ? vwap - 3.0 * sd  : na
 
-// ── Previous-year reference lines (horizontal carry-forward) ─────────────────
-// style_linebr breaks across gaps; for a solid carry-forward use style_line
-plot(show_prev and not na(prev_vwap)             ? prev_vwap             : na, "Prev VWAP",   c_prev, 1, plot.style_linebr)
-plot(show_prev and not na(prev_sd)               ? prev_vwap + prev_sd   : na, "Prev VAH +1", c_prev, 1, plot.style_linebr)
-plot(show_prev and not na(prev_sd)               ? prev_vwap - prev_sd   : na, "Prev VAL -1", c_prev, 1, plot.style_linebr)
-plot(show_prev and not na(prev_sd) and show_sd2  ? prev_vwap + 2*prev_sd : na, "Prev VAH +2", c_prev, 1, plot.style_linebr)
-plot(show_prev and not na(prev_sd) and show_sd2  ? prev_vwap - 2*prev_sd : na, "Prev VAL -2", c_prev, 1, plot.style_linebr)
-plot(show_prev and not na(prev_sd) and show_sd3  ? prev_vwap + 3*prev_sd : na, "Prev VAH +3", c_prev, 1, plot.style_linebr)
-plot(show_prev and not na(prev_sd) and show_sd3  ? prev_vwap - 3*prev_sd : na, "Prev VAL -3", c_prev, 1, plot.style_linebr)
+pvhi = not na(prev_sd) ? prev_vwap + prev_sd : na
+pvlo = not na(prev_sd) ? prev_vwap - prev_sd : na
 
-// ── Alerts ───────────────────────────────────────────────────────────────────
-alertcondition(ta.cross(close, vwap),        "Price x VWAP",    "Price crossed Yearly VWAP")
-alertcondition(ta.cross(close, vwap + sd),   "Price x VAH +1",  "Price crossed +1 SD band")
-alertcondition(ta.cross(close, vwap - sd),   "Price x VAL -1",  "Price crossed -1 SD band")
+// ── Plots ─────────────────────────────────────────────────────────────────────
+p_vwap  = plot(vwap,                 "VWAP",  c_vwap, 2)
+p_vhi   = plot(show_sd1 ? vhi : na, "VAH",   c_vah,  1)
+p_vlo   = plot(show_sd1 ? vlo : na, "VAL",   c_val,  1)
+plot(show_sd2 ? vhi2 : na,           "VAH+2", c_sd2,  1)
+plot(show_sd2 ? vlo2 : na,           "VAL-2", c_sd2,  1)
+plot(show_sd3 ? vhi3 : na,           "VAH+3", c_sd3,  1)
+plot(show_sd3 ? vlo3 : na,           "VAL-3", c_sd3,  1)
+
+p_pvwap = plot(show_prev ? prev_vwap : na, "P.VWAP", c_pvwap, 1, plot.style_linebr)
+p_pvhi  = plot(show_prev ? pvhi      : na, "P.VAH",  c_pvah,  1, plot.style_linebr)
+p_pvlo  = plot(show_prev ? pvlo      : na, "P.VAL",  c_pval,  1, plot.style_linebr)
+
+fill(p_vhi,  p_vlo,  shade_dev  and show_sd1  ? c_fill_dev : na)
+fill(p_pvhi, p_pvlo, shade_prev and show_prev ? c_fill_prv : na)
+
+// ── Extension lines (dashed, developing period) ───────────────────────────────
+var line ext_vwap_ln = na
+var line ext_vhi_ln  = na
+var line ext_vlo_ln  = na
+
+if show_ext
+    if new_period
+        if not na(ext_vwap_ln)
+            line.delete(ext_vwap_ln)
+        if not na(ext_vhi_ln)
+            line.delete(ext_vhi_ln)
+        if not na(ext_vlo_ln)
+            line.delete(ext_vlo_ln)
+        if not na(vwap)
+            ext_vwap_ln := line.new(bar_index, vwap, bar_index + 1, vwap,
+                 extend=extend.right, style=line.style_dashed, color=c_vwap, width=1)
+        if not na(vhi)
+            ext_vhi_ln := line.new(bar_index, vhi, bar_index + 1, vhi,
+                 extend=extend.right, style=line.style_dashed, color=c_vah, width=1)
+        if not na(vlo)
+            ext_vlo_ln := line.new(bar_index, vlo, bar_index + 1, vlo,
+                 extend=extend.right, style=line.style_dashed, color=c_val, width=1)
+    else
+        if not na(ext_vwap_ln) and not na(vwap)
+            line.set_y1(ext_vwap_ln, vwap)
+            line.set_y2(ext_vwap_ln, vwap)
+        if not na(ext_vhi_ln) and not na(vhi)
+            line.set_y1(ext_vhi_ln, vhi)
+            line.set_y2(ext_vhi_ln, vhi)
+        if not na(ext_vlo_ln) and not na(vlo)
+            line.set_y1(ext_vlo_ln, vlo)
+            line.set_y2(ext_vlo_ln, vlo)
+
+// ── Label prefixes based on effective timeframe ───────────────────────────────
+// Developing: dy=Yearly, dq=Quarterly, dm=Monthly, dw=Weekly, dd=Daily
+// Previous:   py=Yearly, pq=Quarterly, pm=Monthly, pw=Weekly, pd=Daily
+d_pfx = eff_tf == "Yearly"    ? "dy" :
+        eff_tf == "Quarterly" ? "dq" :
+        eff_tf == "Monthly"   ? "dm" :
+        eff_tf == "Weekly"    ? "dw" : "dd"
+
+p_pfx = eff_tf == "Yearly"    ? "py" :
+        eff_tf == "Quarterly" ? "pq" :
+        eff_tf == "Monthly"   ? "pm" :
+        eff_tf == "Weekly"    ? "pw" : "pd"
+
+// ── Labels ────────────────────────────────────────────────────────────────────
+// Developing labels: 10% of visible range to the right of last bar
+// Previous labels:   20% of visible range to the right of last bar
+var label lbl_dvwap = na
+var label lbl_dvah  = na
+var label lbl_dval  = na
+var label lbl_pvwap = na
+var label lbl_pvah  = na
+var label lbl_pval  = na
+
+if show_lbl and barstate.islast
+    vis_range = chart.right_visible_bar_time - chart.left_visible_bar_time
+    dev_x = time + int(vis_range * 0.10)
+    prv_x = time + int(vis_range * 0.20)
+
+    label.delete(lbl_dvwap)
+    label.delete(lbl_dvah)
+    label.delete(lbl_dval)
+
+    if not na(vwap)
+        lbl_dvwap := label.new(dev_x, vwap,
+             d_pfx + "VWAP " + str.tostring(vwap, format.mintick),
+             xloc=xloc.bar_time, style=label.style_label_left,
+             color=c_lbl_d_bg, textcolor=c_lbl_d_tx, size=size.small)
+    if not na(vhi)
+        lbl_dvah := label.new(dev_x, vhi,
+             d_pfx + "VAH " + str.tostring(vhi, format.mintick),
+             xloc=xloc.bar_time, style=label.style_label_left,
+             color=c_lbl_d_bg, textcolor=c_lbl_d_tx, size=size.small)
+    if not na(vlo)
+        lbl_dval := label.new(dev_x, vlo,
+             d_pfx + "VAL " + str.tostring(vlo, format.mintick),
+             xloc=xloc.bar_time, style=label.style_label_left,
+             color=c_lbl_d_bg, textcolor=c_lbl_d_tx, size=size.small)
+
+    if show_prev
+        label.delete(lbl_pvwap)
+        label.delete(lbl_pvah)
+        label.delete(lbl_pval)
+
+        if not na(prev_vwap)
+            lbl_pvwap := label.new(prv_x, prev_vwap,
+                 p_pfx + "VWAP " + str.tostring(prev_vwap, format.mintick),
+                 xloc=xloc.bar_time, style=label.style_label_left,
+                 color=c_lbl_p_bg, textcolor=c_lbl_p_tx, size=size.small)
+        if not na(pvhi)
+            lbl_pvah := label.new(prv_x, pvhi,
+                 p_pfx + "VAH " + str.tostring(pvhi, format.mintick),
+                 xloc=xloc.bar_time, style=label.style_label_left,
+                 color=c_lbl_p_bg, textcolor=c_lbl_p_tx, size=size.small)
+        if not na(pvlo)
+            lbl_pval := label.new(prv_x, pvlo,
+                 p_pfx + "VAL " + str.tostring(pvlo, format.mintick),
+                 xloc=xloc.bar_time, style=label.style_label_left,
+                 color=c_lbl_p_bg, textcolor=c_lbl_p_tx, size=size.small)
+
+// ── Alerts ────────────────────────────────────────────────────────────────────
+alertcondition(ta.cross(close, vwap),      "Price x VWAP",      "Price crossed VWAP")
+alertcondition(ta.cross(close, vhi),       "Price x VAH",       "Price crossed VAH (+1 SD)")
+alertcondition(ta.cross(close, vlo),       "Price x VAL",       "Price crossed VAL (-1 SD)")
+alertcondition(ta.cross(close, prev_vwap), "Price x Prev VWAP", "Price crossed Previous VWAP")


### PR DESCRIPTION
- Add Daily value area; auto-selects when chart TF < 30 min
- Adjust Weekly auto range: 30m up to (not including) 1 hour
- Add 'Shade Previous Value Area' toggle (off by default)
- Label prefixes now encode timeframe: Developing — dy/dq/dm/dw/dd (Yearly/Quarterly/Monthly/Weekly/Daily)
    Previous   — py/pq/pm/pw/pd
- Developing labels fixed 10% of visible range to the right of last bar
- Previous labels offset a further 10% (20% total) from last bar
- Full Pine Script v6 rewrite: string literals for all group= params,
  no var string group variables, na guards on line.delete calls