### PR TITLE
fix: VWAP syntax error at line 161 (switch expression)

### DIFF
--- a/yearly_anchored_vwap.pine
+++ b/yearly_anchored_vwap.pine
@@ -155,15 +155,19 @@ if show_ext
 // ── Label prefixes based on effective timeframe ───────────────────────────────
 // Developing: dy=Yearly, dq=Quarterly, dm=Monthly, dw=Weekly, dd=Daily
 // Previous:   py=Yearly, pq=Quarterly, pm=Monthly, pw=Weekly, pd=Daily
-d_pfx = eff_tf == "Yearly"    ? "dy" :
-        eff_tf == "Quarterly" ? "dq" :
-        eff_tf == "Monthly"   ? "dm" :
-        eff_tf == "Weekly"    ? "dw" : "dd"
+d_pfx = switch eff_tf
+    "Yearly"    => "dy"
+    "Quarterly" => "dq"
+    "Monthly"   => "dm"
+    "Weekly"    => "dw"
+    => "dd"
 
-p_pfx = eff_tf == "Yearly"    ? "py" :
-        eff_tf == "Quarterly" ? "pq" :
-        eff_tf == "Monthly"   ? "pm" :
-        eff_tf == "Weekly"    ? "pw" : "pd"
+p_pfx = switch eff_tf
+    "Yearly"    => "py"
+    "Quarterly" => "pq"
+    "Monthly"   => "pm"
+    "Weekly"    => "pw"
+    => "pd"
 
 // ── Labels ────────────────────────────────────────────────────────────────────
 // Developing labels: 10% of visible range to the right of last bar


### PR DESCRIPTION
Fixes "Syntax error at input end of line without line continuation" at line 161 of yearly_anchored_vwap.pine.

Replaced multi-line chained ternary operators for d_pfx and p_pfx with switch expressions (idiomatic Pine Script v6 syntax).

Closes #5

Generated with [Claude Code](https://claude.ai/code)