### PR TITLE
fix: VWAP - restore Band 3 toggle, fix hlc3 typical price

### DIFF
--- a/agg_vwap.pine
+++ b/agg_vwap.pine
@@ -60,7 +60,8 @@ anchor4_y = input.int(2024, "VWAP 4 Anchor Year",  minval=2009, group=g_anchors)
 anchor4_m = input.int(4,    "VWAP 4 Anchor Month", minval=1, maxval=12, group=g_anchors)
 anchor4_d = input.int(20,   "VWAP 4 Anchor Day",   minval=1, maxval=31, group=g_anchors)
 
-show_bands34 = input.bool(true,  "Show SD Bands (VWAP 3 & 4)", group=g_disp)
+show_bands3  = input.bool(true,  "Show SD Bands (VWAP 3)",     group=g_disp)
+show_bands4  = input.bool(true,  "Show SD Bands (VWAP 4)",     group=g_disp)
 show_bands12 = input.bool(false, "Show SD Bands (VWAP 1 & 2)", group=g_disp,
   tooltip="Bands 1 & 2 are empty in the original CSV export — enable only for reference.")
 
@@ -79,7 +80,7 @@ vwap_from_anchor(anchor_y, anchor_m, anchor_d) =>
     var float _vol  = 0.0
     var float _tp2v = 0.0
 
-    _tp = close  // Backtest confirmed: close outperforms (H+L+C)/3 by 70x for VWAP accuracy
+    _tp = hlc3  // Standard VWAP typical price: (High + Low + Close) / 3
 
     _is_anchor = year(time) == anchor_y and month(time) == anchor_m and dayofmonth(time) == anchor_d
     _reset     = _is_anchor or (barstate.isfirst and
@@ -118,13 +119,13 @@ p3 = plot(vwap3, "VWAP 3", c3, 2)
 p4 = plot(vwap4, "VWAP 4", c4, 2)
 
 // SD Bands — VWAP 3 (original CSV has bands 3 and 4 populated)
-p3u = plot(show_bands34 ? vwap3 + sd3 : na, "Upper Band 3", color.new(c3, 40), 1)
-p3l = plot(show_bands34 ? vwap3 - sd3 : na, "Lower Band 3", color.new(c3, 40), 1)
+p3u = plot(show_bands3 ? vwap3 + sd3 : na, "Upper Band 3", color.new(c3, 40), 1)
+p3l = plot(show_bands3 ? vwap3 - sd3 : na, "Lower Band 3", color.new(c3, 40), 1)
 fill(p3u, p3l, color.new(c3, 90), "Band 3 Fill")
 
 // SD Bands — VWAP 4
-p4u = plot(show_bands34 ? vwap4 + sd4 : na, "Upper Band 4", color.new(c4, 40), 1)
-p4l = plot(show_bands34 ? vwap4 - sd4 : na, "Lower Band 4", color.new(c4, 40), 1)
+p4u = plot(show_bands4 ? vwap4 + sd4 : na, "Upper Band 4", color.new(c4, 40), 1)
+p4l = plot(show_bands4 ? vwap4 - sd4 : na, "Lower Band 4", color.new(c4, 40), 1)
 fill(p4u, p4l, color.new(c4, 90), "Band 4 Fill")
 
 // SD Bands — VWAP 1 & 2 (optional, empty in original)

--- a/yearly_anchored_vwap.pine
+++ b/yearly_anchored_vwap.pine
@@ -87,7 +87,7 @@ var float cum_tp2v = 0.0
 var float prev_vwap = na
 var float prev_sd   = na
 
-tp = close
+tp = hlc3  // Standard VWAP typical price: (High + Low + Close) / 3
 
 if new_period
     if cum_vol > 0.0


### PR DESCRIPTION
Fixes #11

## Changes

**agg_vwap.pine**
- Restored independent "Show SD Bands (VWAP 3)" and "Show SD Bands (VWAP 4)" toggles (previously merged into one)
- Changed typical price from `close` to `hlc3` ((H+L+C)/3)

**yearly_anchored_vwap.pine**
- Changed typical price from `close` to `hlc3`

Using `close` instead of the standard typical price caused VWAP and SD band levels to diverge from other VWAP indicators.

Generated with [Claude Code](https://claude.ai/code)