### PR TITLE
feat: Rolling VWAP day duration, BloFin/Bitget/CoinEx, exchange toggles tab

### DIFF
--- a/Agg-MTF-VWAP.pine
+++ b/Agg-MTF-VWAP.pine
@@ -1,5 +1,5 @@
 //@version=6
-indicator("Agg-MTF-VWAP", shorttitle="Agg-VWAP", overlay=true, max_lines_count=500, max_labels_count=50)
+indicator("Agg-MTF-VWAP", shorttitle="Agg-VWAP", overlay=true, max_lines_count=500, max_labels_count=500)
 
 // ── Timeframe ─────────────────────────────────────────────────────────────────
 tf_mode = input.string("Auto", "Timeframe",
@@ -17,31 +17,37 @@ use_dynamic  = input.bool(true,  "Auto-detect pair from chart (Dynamic Mode)",
 
 inp_binance  = input.symbol("BINANCE:BTCUSDT",  "Binance",  group=grp_src,
      tooltip="Used only when Dynamic Mode is OFF")
-use_binance  = input.bool(true, "Include", inline="bnb",  group=grp_src)
-
 inp_bybit    = input.symbol("BYBIT:BTCUSDT",    "Bybit",    group=grp_src,
      tooltip="Used only when Dynamic Mode is OFF")
-use_bybit    = input.bool(true, "Include", inline="byb",  group=grp_src)
-
 inp_coinbase = input.symbol("COINBASE:BTCUSD",  "Coinbase", group=grp_src,
      tooltip="Used only when Dynamic Mode is OFF.\nIn Dynamic Mode, Coinbase quote currency is auto-converted (USDT → USD)")
-use_coinbase = input.bool(true, "Include", inline="cb",   group=grp_src)
-
 inp_kraken   = input.symbol("KRAKEN:XBTUSD",    "Kraken",   group=grp_src,
      tooltip="Used only when Dynamic Mode is OFF.\nIn Dynamic Mode, Kraken base currency is auto-converted (BTC → XBT) and quote (USDT → USD)")
-use_kraken   = input.bool(true, "Include", inline="kr",   group=grp_src)
-
 inp_mexc     = input.symbol("MEXC:BTCUSDT",     "MEXC",     group=grp_src,
      tooltip="Used only when Dynamic Mode is OFF")
-use_mexc     = input.bool(true, "Include", inline="mx",   group=grp_src)
-
 inp_okx      = input.symbol("OKX:BTCUSDT",      "OKX",      group=grp_src,
      tooltip="Used only when Dynamic Mode is OFF")
-use_okx      = input.bool(true, "Include", inline="okx",  group=grp_src)
-
 inp_kucoin   = input.symbol("KUCOIN:BTCUSDT",   "KuCoin",   group=grp_src,
      tooltip="Used only when Dynamic Mode is OFF")
-use_kucoin   = input.bool(true, "Include", inline="kuc",  group=grp_src)
+inp_blofin   = input.symbol("BLOFIN:BTCUSDT",   "BloFin",   group=grp_src,
+     tooltip="Used only when Dynamic Mode is OFF")
+inp_bitget   = input.symbol("BITGET:BTCUSDT",   "Bitget",   group=grp_src,
+     tooltip="Used only when Dynamic Mode is OFF")
+inp_coinex   = input.symbol("COINEX:BTCUSDT",   "CoinEx",   group=grp_src,
+     tooltip="Used only when Dynamic Mode is OFF")
+
+// ── Exchange Toggles ───────────────────────────────────────────────────────────
+grp_tog      = "Exchange Toggles"
+use_binance  = input.bool(true, "Binance",  group=grp_tog)
+use_bybit    = input.bool(true, "Bybit",    group=grp_tog)
+use_coinbase = input.bool(true, "Coinbase", group=grp_tog)
+use_kraken   = input.bool(true, "Kraken",   group=grp_tog)
+use_mexc     = input.bool(true, "MEXC",     group=grp_tog)
+use_okx      = input.bool(true, "OKX",      group=grp_tog)
+use_kucoin   = input.bool(true, "KuCoin",   group=grp_tog)
+use_blofin   = input.bool(true, "BloFin",   group=grp_tog)
+use_bitget   = input.bool(true, "Bitget",   group=grp_tog)
+use_coinex   = input.bool(true, "CoinEx",   group=grp_tog)
 
 // ── Display ───────────────────────────────────────────────────────────────────
 show_sd1   = input.bool(true,  "Show Value Area (±1 SD)",        group="Display")
@@ -58,6 +64,18 @@ shade_dev  = input.bool(true,  "Shade Developing Value Area",     group="Display
 shade_prev = input.bool(false, "Shade Previous Value Area",       group="Display")
 show_lbl   = input.bool(true,  "Show Labels",                     group="Display")
 show_ext   = input.bool(true,  "Extend Developing Lines to RHS",  group="Display")
+
+// ── Rolling VWAP ──────────────────────────────────────────────────────────────
+grp_rv     = "Rolling VWAP"
+rv_show    = input.bool(false, "Enable Rolling VWAP",              group=grp_rv)
+rv_days    = input.int(30,     "Duration (days)", minval=1,         group=grp_rv,
+     tooltip="Number of calendar days to look back for the rolling VWAP.\nExamples: 18 days, 70 days, 365 days.\n\nNote: very large values on low timeframe charts may exceed Pine Script's maximum lookback limit.")
+rv_show_sd = input.bool(false, "Show ±1 SD Bands (rvVAH / rvVAL)", group=grp_rv)
+rv_shade   = input.bool(false, "Shade Rolling Value Area",          group=grp_rv)
+c_rv_vwap  = input.color(color.new(#FF9800, 0),  "rvVWAP colour",  group=grp_rv)
+c_rv_vah   = input.color(color.new(#FF5722, 0),  "rvVAH colour",   group=grp_rv)
+c_rv_val   = input.color(color.new(#FF5722, 0),  "rvVAL colour",   group=grp_rv)
+c_rv_fill  = input.color(color.new(#FF9800, 85), "rvVA Fill",      group=grp_rv)
 
 // ── Colours: Developing ───────────────────────────────────────────────────────
 c_vwap     = input.color(color.new(#2196F3, 0),  "VWAP",            group="Colours: Developing")
@@ -82,16 +100,10 @@ c_lbl_p_bg = input.color(color.new(#9E9E9E, 10), "Prev Label BG",   group="Colou
 c_lbl_p_tx = input.color(color.white,             "Prev Label Text", group="Colours: Labels")
 
 // ── Dynamic symbol construction ───────────────────────────────────────────────
-// syminfo.basecurrency and syminfo.currency reflect the current chart symbol.
-// These are simple strings (constant throughout the script run) so they can be
-// used in request.security() calls safely.
-_base  = syminfo.basecurrency   // e.g. "BTC", "ETH", "SOL"
-_quote = syminfo.currency        // e.g. "USDT", "USD"
+_base  = syminfo.basecurrency
+_quote = syminfo.currency
 
-// Coinbase lists most assets against USD, not USDT
 _cb_quote = str.replace(_quote, "USDT", "USD")
-
-// Kraken uses "XBT" for Bitcoin and "USD" instead of "USDT"
 _kr_base  = _base == "BTC" ? "XBT" : _base
 _kr_quote = str.replace(_quote, "USDT", "USD")
 
@@ -102,11 +114,11 @@ sym_kraken   = use_dynamic ? "KRAKEN:"   + _kr_base + _kr_quote : inp_kraken
 sym_mexc     = use_dynamic ? "MEXC:"     + _base    + _quote    : inp_mexc
 sym_okx      = use_dynamic ? "OKX:"      + _base    + _quote    : inp_okx
 sym_kucoin   = use_dynamic ? "KUCOIN:"   + _base    + _quote    : inp_kucoin
+sym_blofin   = use_dynamic ? "BLOFIN:"   + _base    + _quote    : inp_blofin
+sym_bitget   = use_dynamic ? "BITGET:"   + _base    + _quote    : inp_bitget
+sym_coinex   = use_dynamic ? "COINEX:"   + _base    + _quote    : inp_coinex
 
 // ── Data fetching ─────────────────────────────────────────────────────────────
-// ignore_invalid_symbol=true: if an exchange doesn't list this pair, the call
-// returns na instead of an error — the nz() wrappers in the aggregation below
-// convert na → 0, silently excluding that exchange.
 [tp_bnb, vol_bnb] = request.security(sym_binance,  timeframe.period, [hlc3, volume], ignore_invalid_symbol=true)
 [tp_byb, vol_byb] = request.security(sym_bybit,    timeframe.period, [hlc3, volume], ignore_invalid_symbol=true)
 [tp_cb,  vol_cb]  = request.security(sym_coinbase, timeframe.period, [hlc3, volume], ignore_invalid_symbol=true)
@@ -114,10 +126,11 @@ sym_kucoin   = use_dynamic ? "KUCOIN:"   + _base    + _quote    : inp_kucoin
 [tp_mx,  vol_mx]  = request.security(sym_mexc,     timeframe.period, [hlc3, volume], ignore_invalid_symbol=true)
 [tp_okx, vol_okx] = request.security(sym_okx,      timeframe.period, [hlc3, volume], ignore_invalid_symbol=true)
 [tp_kuc, vol_kuc] = request.security(sym_kucoin,   timeframe.period, [hlc3, volume], ignore_invalid_symbol=true)
+[tp_blf, vol_blf] = request.security(sym_blofin,   timeframe.period, [hlc3, volume], ignore_invalid_symbol=true)
+[tp_btg, vol_btg] = request.security(sym_bitget,   timeframe.period, [hlc3, volume], ignore_invalid_symbol=true)
+[tp_cex, vol_cex] = request.security(sym_coinex,   timeframe.period, [hlc3, volume], ignore_invalid_symbol=true)
 
 // ── Per-bar aggregation helpers ───────────────────────────────────────────────
-// An exchange is included only if its toggle is on AND it returned valid data.
-// Returns 0 when excluded, so it has no effect on the weighted sums.
 f_vol(ena, v)     => ena and not na(v) ? nz(v) : 0.0
 f_tpv(ena, t, v)  => ena and not na(v) ? nz(t) * nz(v) : 0.0
 f_tp2v(ena, t, v) => ena and not na(v) ? nz(t) * nz(t) * nz(v) : 0.0
@@ -125,17 +138,20 @@ f_tp2v(ena, t, v) => ena and not na(v) ? nz(t) * nz(t) * nz(v) : 0.0
 agg_vol  = f_vol (use_binance,  vol_bnb)           + f_vol (use_bybit,    vol_byb)           +
            f_vol (use_coinbase, vol_cb)             + f_vol (use_kraken,   vol_kr)            +
            f_vol (use_mexc,     vol_mx)             + f_vol (use_okx,      vol_okx)           +
-           f_vol (use_kucoin,   vol_kuc)
+           f_vol (use_kucoin,   vol_kuc)            + f_vol (use_blofin,   vol_blf)           +
+           f_vol (use_bitget,   vol_btg)            + f_vol (use_coinex,   vol_cex)
 
 agg_tpv  = f_tpv (use_binance,  tp_bnb, vol_bnb)   + f_tpv (use_bybit,    tp_byb, vol_byb)   +
            f_tpv (use_coinbase, tp_cb,  vol_cb)     + f_tpv (use_kraken,   tp_kr,  vol_kr)    +
            f_tpv (use_mexc,     tp_mx,  vol_mx)     + f_tpv (use_okx,      tp_okx, vol_okx)   +
-           f_tpv (use_kucoin,   tp_kuc, vol_kuc)
+           f_tpv (use_kucoin,   tp_kuc, vol_kuc)    + f_tpv (use_blofin,   tp_blf, vol_blf)   +
+           f_tpv (use_bitget,   tp_btg, vol_btg)    + f_tpv (use_coinex,   tp_cex, vol_cex)
 
 agg_tp2v = f_tp2v(use_binance,  tp_bnb, vol_bnb)   + f_tp2v(use_bybit,    tp_byb, vol_byb)   +
            f_tp2v(use_coinbase, tp_cb,  vol_cb)     + f_tp2v(use_kraken,   tp_kr,  vol_kr)    +
            f_tp2v(use_mexc,     tp_mx,  vol_mx)     + f_tp2v(use_okx,      tp_okx, vol_okx)   +
-           f_tp2v(use_kucoin,   tp_kuc, vol_kuc)
+           f_tp2v(use_kucoin,   tp_kuc, vol_kuc)    + f_tp2v(use_blofin,   tp_blf, vol_blf)   +
+           f_tp2v(use_bitget,   tp_btg, vol_btg)    + f_tp2v(use_coinex,   tp_cex, vol_cex)
 
 // ── Effective timeframe ───────────────────────────────────────────────────────
 tf_secs = timeframe.in_seconds()
@@ -196,6 +212,20 @@ vlo3 = not na(sd) ? vwap - sd3_mult * sd : na
 pvhi = not na(prev_sd) ? prev_vwap + prev_sd : na
 pvlo = not na(prev_sd) ? prev_vwap - prev_sd : na
 
+// ── Rolling VWAP computation ──────────────────────────────────────────────────
+// Converts the day duration into a bar count, then sums using a rolling window.
+// Uses the same aggregated cross-exchange data as the main VWAP.
+rv_bars     = math.max(1, math.round(rv_days * 86400 / tf_secs))
+rv_sum_vol  = math.sum(agg_vol,  rv_bars)
+rv_sum_tpv  = math.sum(agg_tpv,  rv_bars)
+rv_sum_tp2v = math.sum(agg_tp2v, rv_bars)
+
+rv_vwap    = rv_show and rv_sum_vol > 0.0 ? rv_sum_tpv / rv_sum_vol : na
+_rv_var    = rv_show and rv_sum_vol > 0.0 ? math.max(rv_sum_tp2v / rv_sum_vol - (rv_sum_tpv / rv_sum_vol) * (rv_sum_tpv / rv_sum_vol), 0.0) : na
+rv_sd      = not na(_rv_var) ? math.sqrt(_rv_var) : na
+rv_vah     = rv_show and rv_show_sd and not na(rv_sd) ? rv_vwap + rv_sd : na
+rv_val     = rv_show and rv_show_sd and not na(rv_sd) ? rv_vwap - rv_sd : na
+
 // ── Plots ─────────────────────────────────────────────────────────────────────
 p_vwap  = plot(vwap,                  "VWAP",    c_vwap, 2)
 p_vhi   = plot(show_sd1 ? vhi  : na, "VAH",     c_vah,  1)
@@ -209,11 +239,16 @@ p_pvwap = plot(show_prev ? prev_vwap : na, "P.VWAP", c_pvwap, 1, plot.style_line
 p_pvhi  = plot(show_prev ? pvhi      : na, "P.VAH",  c_pvah,  1, plot.style_linebr)
 p_pvlo  = plot(show_prev ? pvlo      : na, "P.VAL",  c_pval,  1, plot.style_linebr)
 
+p_rv_vwap = plot(rv_vwap, "rvVWAP", c_rv_vwap, 2)
+p_rv_vah  = plot(rv_vah,  "rvVAH",  c_rv_vah,  1)
+p_rv_val  = plot(rv_val,  "rvVAL",  c_rv_val,  1)
+
 // ── Fills ─────────────────────────────────────────────────────────────────────
-fill(p_vhi,  p_vlo,  shade_dev  and show_sd1  ? c_fill_dev : na)
-fill(p_pvhi, p_pvlo, shade_prev and show_prev ? c_fill_prv : na)
-fill(p_vhi2, p_vlo2, shade_sd2  and show_sd2  ? c_fill_sd2 : na)
-fill(p_vhi3, p_vlo3, shade_sd3  and show_sd3  ? c_fill_sd3 : na)
+fill(p_vhi,    p_vlo,    shade_dev  and show_sd1               ? c_fill_dev : na)
+fill(p_pvhi,   p_pvlo,   shade_prev and show_prev              ? c_fill_prv : na)
+fill(p_vhi2,   p_vlo2,   shade_sd2  and show_sd2               ? c_fill_sd2 : na)
+fill(p_vhi3,   p_vlo3,   shade_sd3  and show_sd3               ? c_fill_sd3 : na)
+fill(p_rv_vah, p_rv_val, rv_shade   and rv_show and rv_show_sd ? c_rv_fill  : na)
 
 // ── Extension lines ───────────────────────────────────────────────────────────
 var line ext_vwap_ln  = na
@@ -287,17 +322,21 @@ p_pfx = switch eff_tf
     => "pd"
 
 // ── Labels ────────────────────────────────────────────────────────────────────
-var label lbl_dvwap = na
-var label lbl_dvah  = na
-var label lbl_dval  = na
-var label lbl_pvwap = na
-var label lbl_pvah  = na
-var label lbl_pval  = na
+var label lbl_dvwap   = na
+var label lbl_dvah    = na
+var label lbl_dval    = na
+var label lbl_pvwap   = na
+var label lbl_pvah    = na
+var label lbl_pval    = na
+var label lbl_rv_vwap = na
+var label lbl_rv_vah  = na
+var label lbl_rv_val  = na
 
 if show_lbl and barstate.islast
     vis_range = chart.right_visible_bar_time - chart.left_visible_bar_time
     dev_x = time + int(vis_range * 0.10)
     prv_x = time + int(vis_range * 0.20)
+    rv_x  = time + int(vis_range * 0.15)
 
     label.delete(lbl_dvwap)
     label.delete(lbl_dvah)
@@ -340,8 +379,32 @@ if show_lbl and barstate.islast
                  xloc=xloc.bar_time, style=label.style_label_left,
                  color=c_lbl_p_bg, textcolor=c_lbl_p_tx, size=size.small)
 
+    if rv_show
+        label.delete(lbl_rv_vwap)
+        label.delete(lbl_rv_vah)
+        label.delete(lbl_rv_val)
+
+        if not na(rv_vwap)
+            lbl_rv_vwap := label.new(rv_x, rv_vwap,
+                 "rvVWAP(" + str.tostring(rv_days) + "d) " + str.tostring(rv_vwap, format.mintick),
+                 xloc=xloc.bar_time, style=label.style_label_left,
+                 color=color.new(c_rv_vwap, 10), textcolor=color.white, size=size.small)
+        if not na(rv_vah)
+            lbl_rv_vah := label.new(rv_x, rv_vah,
+                 "rvVAH(" + str.tostring(rv_days) + "d) " + str.tostring(rv_vah, format.mintick),
+                 xloc=xloc.bar_time, style=label.style_label_left,
+                 color=color.new(c_rv_vah, 10), textcolor=color.white, size=size.small)
+        if not na(rv_val)
+            lbl_rv_val := label.new(rv_x, rv_val,
+                 "rvVAL(" + str.tostring(rv_days) + "d) " + str.tostring(rv_val, format.mintick),
+                 xloc=xloc.bar_time, style=label.style_label_left,
+                 color=color.new(c_rv_val, 10), textcolor=color.white, size=size.small)
+
 // ── Alerts ────────────────────────────────────────────────────────────────────
 alertcondition(ta.cross(close, vwap),      "Price x VWAP",      "Price crossed Agg-VWAP")
 alertcondition(ta.cross(close, vhi),       "Price x VAH",       "Price crossed Agg-VAH (+1 SD)")
 alertcondition(ta.cross(close, vlo),       "Price x VAL",       "Price crossed Agg-VAL (-1 SD)")
 alertcondition(ta.cross(close, prev_vwap), "Price x Prev VWAP", "Price crossed Previous Agg-VWAP")
+alertcondition(ta.cross(close, rv_vwap),   "Price x rvVWAP",    "Price crossed Rolling VWAP")
+alertcondition(ta.cross(close, rv_vah),    "Price x rvVAH",     "Price crossed Rolling VAH (+1 SD)")
+alertcondition(ta.cross(close, rv_val),    "Price x rvVAL",     "Price crossed Rolling VAL (-1 SD)")


### PR DESCRIPTION
Resolves #15

## Changes

- **Rolling VWAP day duration input**: replace timeframe dropdown with an integer "Duration (days)" field — type any value (e.g. 18, 70, 365); bar count is derived via `rv_bars = round(rv_days × 86400 / tf_secs)` and summed with `math.sum()` over the aggregated cross-exchange data
- **Labels**: `rvVWAP(30d)` / `rvVAH(30d)` / `rvVAL(30d)` with day count shown
- **New exchanges**: BloFin, Bitget, CoinEx added with symbol inputs + toggles
- **Exchange Toggles tab**: all on/off checkboxes in a dedicated settings group
- **Alerts**: added for rvVWAP, rvVAH, rvVAL crosses

Generated with [Claude Code](https://claude.ai/code)) • [View job run](https://github.com/josh-vincent/trading-view-indy/actions/runs/22274618126) • [`claude/issue-15-20260222-0936`](https://github.com/josh-vincent/trading-view-indy/tree/claude/issue-15-20260222-0936