### PR TITLE
fix: remove invalid 'extend' type keyword in gap hunter script

### DIFF
--- a/Lowkeighs20Hunter.pine
+++ b/Lowkeighs20Hunter.pine
@@ -71,7 +71,7 @@ if htf_new_bar
         float  bot_price = is_bull ? htf_prev_close : htf_open
         float  mid_price = (top_price + bot_price) / 2.0
         color  fill_col  = is_bull ? bull_col : bear_col
-        extend ext       = extend_box ? extend.right : extend.none
+        ext              = extend_box ? extend.right : extend.none
 
         box b = box.new(
              left         = bar_index,


### PR DESCRIPTION
Fix for "extend" is not a valid type keyword error in the gap hunter script.

In Pine Script v6, `extend` is a built-in enum and cannot be used as a variable type declaration. Removed the explicit type annotation so Pine Script infers the type from the assigned value.

Closes #29

Generated with [Claude Code](https://claude.ai/code)