### PR TITLE
fix: correct Pine Script v6 typed parameter syntax in f_zscore

### DIFF
--- a/agg_spot_perps_volume.pine
+++ b/agg_spot_perps_volume.pine
@@ -131,7 +131,7 @@ perp_s = ta.sma(perp_val, i_smooth)
 // Each series is independently normalised to its own z-score so spot and perps
 // are directly comparable on the same visual scale regardless of raw magnitude.
 // A z-score of 0 = the mean, ±1 = one standard deviation from the mean.
-f_zscore(src float, len int) =>
+f_zscore(float src, int len) =>
     avg = ta.sma(src, len)
     std = ta.stdev(src, len)
     std > 0 ? (src - avg) / std : 0.0


### PR DESCRIPTION
Fixes #issue-44

## Changes

- Fixed `f_zscore` function parameter type annotation order in `agg_spot_perps_volume.pine`
- In Pine Script v6, typed parameters use `type paramName` order (type first), not `paramName type`
- Changed `f_zscore(src float, len int)` to `f_zscore(float src, int len)`

## Scan Results
All other .pine files were checked and are free of similar issues.

Generated with [Claude Code](https://claude.ai/code)