### PR TITLE
fix: replace input.select with input.string in MMT VWAP settings

### DIFF
--- a/Lowkeigh-LTVW-MMT.js
+++ b/Lowkeigh-LTVW-MMT.js
@@ -25,7 +25,7 @@ indicator("Lowkeigh-LTVW v2", true)
 
 // ── Inputs ────────────────────────────────────────────────────────────────────
 // Timeframe
-const tf_mode    = input.select("Timeframe", "Auto", { options: ["Auto", "Yearly", "Quarterly", "Monthly", "Weekly", "Daily"], group: "Timeframe" })
+const tf_mode    = input.string("Timeframe", "Auto", { options: ["Auto", "Yearly", "Quarterly", "Monthly", "Weekly", "Daily"], group: "Timeframe" })
 
 // Display
 const show_sd1   = input.bool("Show Value Area (±1 SD)", true,  { group: "Display" })


### PR DESCRIPTION
Fixes #63

Replaces invalid `input.select()` call with `input.string()` in the MMT VWAP settings section. The `input.select` function does not exist in the MMT v2 API, causing a TypeError that broke the entire settings panel at load time.

Generated with [Claude Code](https://claude.ai/code)